### PR TITLE
Add version numbers to dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in webmachine-actionview.gemspec
+group :development, :test do
+  gem "rspec"
+  gem "yard"
+  gem "webmachine-test"
+end
+
 gemspec

--- a/webmachine-actionview.gemspec
+++ b/webmachine-actionview.gemspec
@@ -9,16 +9,12 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Russell Garner"]
   gem.email         = ["rgarner@zephyros-systems.co.uk"]
   gem.description   = %q{Brings ActionView to webmachine-ruby}
-  gem.summary       = %q{Want the Rails conventions that you're used to for HTML views in webmachine-ruby? This is your gem.}
+  gem.summary       = %q{Want the Rails conventions that you are used to for HTML views in webmachine-ruby? This is your gem.}
   gem.homepage      = "http://github.com/rgarner/webmachine-actionview"
 
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "yard"
-  gem.add_development_dependency "webmachine-test"
-
-  gem.add_runtime_dependency "webmachine"
-  gem.add_runtime_dependency "activesupport"
-  gem.add_runtime_dependency "actionpack"
+  gem.add_dependency "webmachine", '~> 1.0'
+  gem.add_dependency "activesupport", '~> 3.2'
+  gem.add_dependency "actionpack", '~> 3.2'
 
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Bundler installed actionpack-1.4 as a dependency instead of the latest stable version, so I added the correct version to the gemspec.

Also moved development and test gems to the Gemfile. See https://twitter.com/sferik/status/293444109170012160
